### PR TITLE
Normalize

### DIFF
--- a/train_sdss.py
+++ b/train_sdss.py
@@ -117,6 +117,7 @@ for i in range(n_model):
     model = SpectrumAutoencoder(
             wave_rest,
             n_latent=n_latent,
+            normalize=True,
     )
     print (f"--- Model {i}/{n_model}")
 


### PR DESCRIPTION
This PR implements an output normalization in the generator path. It allows the model of the restframe spectrum $m$ to have arbitrary amplitude and matches the observation $x$ at the end with a (differentiable) least-squares solver, i.e. it searches for $c$ that minimizes $(c\cdot m - x)^2$ (in details also for variable weights).

The option can be activated with `SpectrumAutoencoder(..., normalize=True)`. Doing so should help to address the apparent normalization shift for the same spectra when observed over a different wavelength range (like we have in SDSS and BOSS).