### PR TITLE
option for randomized ordering within batch

### DIFF
--- a/spender/data/sdss.py
+++ b/spender/data/sdss.py
@@ -18,14 +18,14 @@ class SDSS(Instrument):
         super().__init__(SDSS._wave_obs, lsf=lsf, calibration=calibration)
 
     @classmethod
-    def get_data_loader(cls, dir, which=None, tag=None, batch_size=1024, shuffle=False):
+    def get_data_loader(cls, dir, which=None, tag=None, batch_size=1024, shuffle=False, shuffle_instance=False):
         files = cls.list_batches(dir, which=which, tag=tag)
         if which in ["train", "valid"]:
             subset = slice(0,3)
         else:
             subset = None
         load_fct = partial(load_batch, subset=subset)
-        data = BatchedFilesDataset(files, load_fct, shuffle=shuffle)
+        data = BatchedFilesDataset(files, load_fct, shuffle=shuffle, shuffle_instance=shuffle_instance)
         return DataLoader(data, batch_size=batch_size)
 
     @classmethod

--- a/spender/util.py
+++ b/spender/util.py
@@ -26,10 +26,11 @@ def load_batch(batch_name, subset=None):
 # based on https://medium.com/speechmatics/how-to-build-a-streaming-dataloader-with-pytorch-a66dd891d9dd
 class BatchedFilesDataset(IterableDataset):
 
-    def __init__(self, file_list, load_fct, shuffle=False):
+    def __init__(self, file_list, load_fct, shuffle=False, shuffle_instance=False):
         assert len(file_list), "File list cannot be empty"
         self.file_list = file_list
         self.shuffle = shuffle
+        self.shuffle_instance = shuffle_instance
         self.load_fct = load_fct
 
     def process_data(self, idx):
@@ -37,7 +38,10 @@ class BatchedFilesDataset(IterableDataset):
             idx = random.randint(0, len(self.file_list) -1)
         batch_name = self.file_list[idx]
         data = self.load_fct(batch_name)
-        for x in zip(*data):
+        data = list(zip(*data))
+        if self.shuffle_instance:
+            random.shuffle(data)
+        for x in data:
             yield x
 
     def get_stream(self):


### PR DESCRIPTION
This PR allows randomization of the sample order within the batch. Set `shuffle_instance=True` as option for the dataloader. 

Doing so helps for computing similarity across batches. It's not a full solution because similarity is more often computed from samples from the same batch, so it's not fully random. Given that we load the samples in batches, it would be _very_ inefficient to have fully random ordering of the entire dataset, so this is a viable, but not optimal solution.