### PR TITLE
fixed static activation function arguments; cleaned up encoder.mlp.mlp

### DIFF
--- a/train/fp16_train.py
+++ b/train/fp16_train.py
@@ -203,6 +203,10 @@ def load_model(filename, models, instruments):
     model_struct = torch.load(filename, map_location=device)
 
     for i, model in enumerate(models):
+        # backwards compat: encoder.mlp instead of encoder.mlp.mlp
+        if 'encoder.mlp.mlp.0.weight' in model_struct['model'][i].keys():
+            from collections import OrderedDict
+            model_struct['model'][i] = OrderedDict([(k.replace('mlp.mlp', 'mlp'), v) for k, v in model_struct['model'][i].items()])
         # backwards compat: add instrument to encoder
         try:
             model.load_state_dict(model_struct['model'][i], strict=False)

--- a/train/train_sdss.py
+++ b/train/train_sdss.py
@@ -13,6 +13,12 @@ from spender.data.sdss import SDSS
 def load_model(filename, model, instrument):
     device = instrument.wave_obs.device
     model_struct = torch.load(filename, map_location=device)
+    
+    # backwards compat: encoder.mlp instead of encoder.mlp.mlp
+    if 'encoder.mlp.mlp.0.weight' in model_struct['model'].keys():
+        from collections import OrderedDict
+        model_struct['model'] = OrderedDict([(k.replace('mlp.mlp', 'mlp'), v) for k, v in model_struct['model'].items()])
+
     # backwards compat: add instrument to encoder
     try:
         model.load_state_dict(model_struct['model'], strict=False)


### PR DESCRIPTION
This PR fixes a bug in the definition of the MLP activations. When given as arguments in the module implementation, they are only instantiated once, which means that different MLP in the same runtime environment share the same parameters.

Secondly, the MLP is directly derived from `Sequential`. It doesn't have an attribute `mlp` anymore, it _is_ the MLP. This cleanup allows access the the encoder MLP in the same way (namely as `encoder.mlp` instead of `encoder.mlp.mlp`) as the decoder MLP. For opening existing model files, the `load_model` method was adjusted to rename the keys in the parameter dictionary.