### PR TITLE
New interp1d

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,19 @@
 from setuptools import setup
 
-long_description = open('README.md').read()
+long_description = open("README.md").read()
 
 setup(
     name="spender",
     description="Spectrum encoder and decoder",
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     version="0.1",
     license="MIT",
     author="Peter Melchior",
     author_email="peter.m.melchior@gmail.com",
     url="https://github.com/pmelchior/spectrum-encoder",
     packages=["spender", "spender.data"],
-    package_data={"skymapper.data": ['*.txt']},
+    package_data={"skymapper.data": ["*.txt"]},
     classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: MIT License",
@@ -22,8 +22,16 @@ setup(
         "Intended Audience :: Science/Research",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Topic :: Scientific/Engineering :: Astronomy"
+        "Topic :: Scientific/Engineering :: Astronomy",
     ],
-    keywords = ['spectroscopy','autoencoder'],
-    install_requires=["torch", "numpy", "accelerate", "torchinterp1d", "astropy", "humanize", "psutil", "GPUtil"]
+    keywords=["spectroscopy", "autoencoder"],
+    install_requires=[
+        "torch",
+        "numpy",
+        "accelerate",
+        "astropy",
+        "humanize",
+        "psutil",
+        "GPUtil",
+    ],
 )

--- a/spender/data/sdss.py
+++ b/spender/data/sdss.py
@@ -8,10 +8,9 @@ import astropy.table as aTable
 import numpy as np
 import torch
 from torch.utils.data import DataLoader
-from torchinterp1d import interp1d
 
 from ..instrument import Instrument, get_skyline_mask
-from ..util import BatchedFilesDataset, load_batch
+from ..util import BatchedFilesDataset, load_batch, interp1d
 
 
 class SDSS(Instrument):

--- a/spender/model.py
+++ b/spender/model.py
@@ -1,7 +1,6 @@
-import numpy as np
 import torch
 from torch import nn
-from torchinterp1d import interp1d
+from .util import interp1d
 
 
 class MLP(nn.Sequential):


### PR DESCRIPTION
Replaces `torchinterp1d` with a new `interp1d` function in `spender/util.py`

The main motivation is that `torchinterp1d` seems to have some issues with backprop (at least on my machine, also see https://github.com/aliutkus/torchinterp1d/issues/16 and https://github.com/aliutkus/torchinterp1d/issues/17).

The new implementation also clamps at the edges instead of extrapolating. 