### PR TITLE
implement new data flux normalization in AE model

### DIFF
--- a/spender/util.py
+++ b/spender/util.py
@@ -113,3 +113,7 @@ def resample_to_restframe(wave_obs, wave_rest, y, w, z):
     # yrest[msk]=0 # not needed because all spectral elements are weighted
     wrest[msk] = 0
     return yrest, wrest
+
+
+def calc_normalization(x, y, ivar):
+    return ((x * ivar) @ y) / ((x * ivar) @ x)


### PR DESCRIPTION
makes the model work with unnormalized spectra

- the `forward` method takes in an extra optional `weights` argument, which when provided will trigger the normalization
- the `normalize` method works on a single spectrum but in `forward` there is a `torch.vmap` since the rest of the code works with batches of spectra