### PR TITLE
Normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ We decided to do the opposite. We build a custom architecture, which describes t
 
 Doing so clearly separates the responsibilities in the architecture. Spender establishes a restframe that has higher resolution and larger wavelength range than the spectra from which it is trained. The model can be trained from spectra at different redshifts or even from different instruments without the need to standardize the observations. Spender also has an explicit, differentiable redshift dependence, which can be coupled with a redshift estimator for a fully data-driven spectrum analysis pipeline.
 
-## Installation
+## Installation (optional: for development)
 
 The easiest way is `pip install spender`. When installing from the code repo, run `pip install -e .`.
 
 For the time being, you will have to install one dependency manually: `torchinterp1d` is available [here](https://github.com/aliutkus/torchinterp1d).
 
-## Pretrained models
+## Pretrained models (requires no spender install)
 
 We make the best-fitting models discussed in the paper available through the Astro Data Lab Hub. Here's a workflow:
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     description="Spectrum encoder and decoder",
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version="0.2.2",
+    version="0.2.3",
     license="MIT",
     author="Peter Melchior",
     author_email="peter.m.melchior@gmail.com",

--- a/spender/util.py
+++ b/spender/util.py
@@ -113,3 +113,7 @@ def resample_to_restframe(wave_obs, wave_rest, y, w, z):
     # yrest[msk]=0 # not needed because all spectral elements are weighted
     wrest[msk] = 0
     return yrest, wrest
+
+
+def calc_normalization(x, y, ivar):
+    return ((x * ivar) @ y) / ((x * ivar) @ x)

--- a/train/diagnostics.ipynb
+++ b/train/diagnostics.ipynb
@@ -29,9 +29,36 @@
   },
   {
    "cell_type": "markdown",
+   "source": [
+    "## Option 1: Load model explicitly (from local file or hub server, requires spender install)"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import spender\n",
+    "\n",
+    "url = \"https://hub.pmelchior.net/spender.sdss.paperII-c273bb69.pt\"\n",
+    "model = spender.load_model(url, instrument, map_location=torch.device('cpu'))\n",
+    "\n",
+    "# also create the instrument\n",
+    "from spender.data.sdss import SDSS\n",
+    "sdss = SDSS()"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Load model with hub"
+    "## Option 2: Load model with hub (requires no prior spender install)"
    ]
   },
   {
@@ -68,7 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Load data"
+    "## Load data (requires local files)"
    ]
   },
   {
@@ -77,11 +104,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from spender.data.sdss import SDSS\n",
-    "\n",
     "data_path = './DATA'\n",
     "batch_size = 128\n",
-    "dataloader = SDSS.get_data_loader(data_path, tag=\"variable\", which=\"test\", batch_size=batch_size)\n",
+    "dataloader = sdss.get_data_loader(data_path, tag=\"variable\", which=\"test\", batch_size=batch_size)\n",
     "dataloader = accelerator.prepare(dataloader)\n",
     "batch = next(iter(dataloader))\n",
     "spec, w, z, ids, norm, zerr = batch"
@@ -351,7 +376,7 @@
    "source": [
     "# get special set for paper figure 2\n",
     "ids = ((412, 52254, 308), (412, 52250, 129), (410, 51877, 560), (406, 51900, 15), (404, 51877, 83))\n",
-    "spec, w, z, norm, zerr = SDSS.make_batch(data_path, ids)\n",
+    "spec, w, z, norm, zerr = sdss.make_batch(data_path, ids)\n",
     "plot_spec_zoom(model, spec, z, w=w, ids=ids);"
    ]
   },
@@ -370,7 +395,7 @@
    "source": [
     "# get dataloader batch again\n",
     "batch_size = 128\n",
-    "dataloader = SDSS.get_data_loader(data_path, tag=\"variable\", which=\"test\", batch_size=batch_size)\n",
+    "dataloader = sdss.get_data_loader(data_path, tag=\"variable\", which=\"test\", batch_size=batch_size)\n",
     "model, dataloader = accelerator.prepare(model, dataloader)\n",
     "batch = next(iter(dataloader))\n",
     "spec, w, z, ids, norm, zerr = batch"
@@ -543,7 +568,7 @@
    "outputs": [],
    "source": [
     "# data loader with all spectra\n",
-    "dataloader = SDSS.get_data_loader(data_path, tag=\"variable\", batch_size=batch_size)\n",
+    "dataloader = sdss.get_data_loader(data_path, tag=\"variable\", batch_size=batch_size)\n",
     "dataloader = accelerator.prepare(dataloader)\n",
     "\n",
     "ss, losses, halphas, zs, norms, ids = [], [], [], [], [], []\n",
@@ -640,7 +665,7 @@
     "    ids = np.load(filename)\n",
     "\n",
     "    # get batch\n",
-    "    spec, w, z, id, norm, zerr = SDSS.make_batch(data_path, ids)\n",
+    "    spec, w, z, id, norm, zerr = sdss.make_batch(data_path, ids)\n",
     "\n",
     "    with torch.no_grad():\n",
     "        s = model.encode(spec)\n",


### PR DESCRIPTION
Add the ability to normalize the reconstructed spectrum to match the data, which allows to work with spectra that are not flux-normalized.

In the first spender papers, we needed to normalize the input spectra in restframe, which requires that we can access observed spectral elements of some reference restframe wavelength (we chose 5300-5800A), but this limits the range of redshifts over which this normalization can be applied.

This PR brings normalization on-the-fly option. The normalization is still computed in the restframe segment shown above, but now from the restframe _reconstruction_ (rather than the de-redshifted observation). We then solve for the maximum-likelihhood estimator of the constant factor that needs to be multiplied with the reconstruction to match the data. 