### PR TITLE
Update model.py to remove undefined `valid` variable.

### DIFF
--- a/spender/model.py
+++ b/spender/model.py
@@ -565,7 +565,7 @@ class BaseAutoencoder(nn.Module):
         # then loss per object = D (number of non-zero bins)
         # to make it to order unity for comparing losses, divide out L (number of bins)
         # instead of D, so that spectra with more valid bins have larger impact
-        loss_ind = torch.sum(0.5 * w * valid * (y - y_).pow(2), dim=1) / y.shape[1]
+        loss_ind = torch.sum(0.5 * w * (y - y_).pow(2), dim=1) / y.shape[1]
 
         if individual:
             return loss_ind


### PR DESCRIPTION
In line 568 of model.py, the variable `valid` is out of scope. The weight, `w` has already been multiplied by `valid` in line 558 so this reference to `valid` can be removed from the loss function. 
